### PR TITLE
Fixed LanguageList component

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,23 +1,10 @@
 import React from 'react';
-import { useDispatch, useSelector } from "react-redux";
-import { change } from "../../features/language/languageSlice";
 import { LanguageDropDown } from 'components';
 
 interface HeaderProps {
-  category: string;
   pageTitle: string;
 };
-
-interface RootState {
-  language: {
-    value: string;
-  }  
-}
-
-const Header: React.FC<HeaderProps> = ({ pageTitle, category }) => {
-
-  const dispatch = useDispatch();
-  const language = useSelector((state: RootState) => state.language.value);
+const Header: React.FC<HeaderProps> = ({ pageTitle }) => {
 
   return (
     <div 

--- a/src/components/LanguageDropDown/LanguageDropDown.tsx
+++ b/src/components/LanguageDropDown/LanguageDropDown.tsx
@@ -1,29 +1,44 @@
 import React, { useState } from "react";
-import { LanguageList } from "components";
 import globe from "../../images/icons/globe.svg";
 import globeRed from "../../images/icons/globeRed.svg";
+import LanguageList from "components/LanguageList";
 
 export default function LanguageDropDown() {
   const [langPopup, setLangPopup] = useState(false);
-
+  const [langList, setLangList] = useState([
+    { lang: "en", text: "English", selected: true },
+    { lang: "es", text: "Español", selected: false },
+  ]);
+  
   function getLangPopup(over: boolean) {
     setLangPopup(over);
   }
 
+  function getSelected(lang: string) {
+    setLangList((prevState) => {
+        return prevState.map((language) =>
+          lang === language.lang
+            ? { ...language, selected: true }
+            : { ...language, selected: false }
+    )})
+  }
+
   return (
     <div
-      className="relative flex flex-col justify-center items-center"
+      className="flex justify-center items-center relative"
       onMouseOver={() => getLangPopup(true)}
       onMouseOut={() => getLangPopup(false)}
     >
       <div className="w-12 h-12 flex justify-center items-center">
         <img
           src={langPopup ? globeRed : globe}
-          className="h-6 leading-6 cursor-pointer"
+          className="h-6 leading-6 cursor-pointer hover:text-[#343434]"
           alt="language icon"
         />
       </div>
-      {langPopup && <LanguageList getLangPopup={getLangPopup} />}
+      {langPopup && 
+        <LanguageList getLangPopup={getLangPopup} getSelected={getSelected} langList={langList} />
+      }
     </div>
   );
 }

--- a/src/components/LanguageList/LanguageList.tsx
+++ b/src/components/LanguageList/LanguageList.tsx
@@ -1,28 +1,21 @@
-import React, { useState } from "react";
+import React from "react";
 import { useDispatch } from "react-redux";
 import { change } from "../../features/language/languageSlice";
 
-interface LanguageListProps {
-  getLangPopup: (option: boolean) => void;
+interface LangList {
+    lang: string;
+    text: string;
+    selected: boolean;
 }
 
-const LanguageList: React.FC<LanguageListProps> = ({ getLangPopup }) => {
+interface LanguageListProps {
+  getLangPopup: (option: boolean) => void;
+  getSelected: (lang: string) => void;
+  langList: LangList[];
+}
+
+const LanguageList: React.FC<LanguageListProps> = ({ getLangPopup, getSelected, langList }) => {
   const dispatch = useDispatch();
-
-  const [langList, setLangList] = useState([
-    { lang: "en", text: "English", selected: true },
-    { lang: "es", text: "Español", selected: false },
-  ]);
-
-  function getSelected(lang: string) {
-    setLangList(
-      langList.map((language) =>
-        lang === language.lang
-          ? { ...language, selected: true }
-          : { ...language, selected: false }
-      )
-    );
-  }
 
   return (
     <div className="absolute top-12 bg-[#fcd783] shadow-xl rounded-lg w-fit h-fit z-10 shadow-xl p-4">
@@ -32,9 +25,9 @@ const LanguageList: React.FC<LanguageListProps> = ({ getLangPopup }) => {
             key={lang.lang}
             className="cursor-pointer flex flex-row items-center gap-4"
             onClick={() => {
-              getLangPopup(false);
-              dispatch(change(lang.lang));
-              getSelected(lang.lang);
+                getSelected(lang.lang);
+                dispatch(change(lang.lang));
+                getLangPopup(false);
             }}
           >
             <div className="w-5 h-5 rounded-full border-2 border-[#ff6347] flex justify-center items-center">


### PR DESCRIPTION
Fixed LanguageList component
- I turned the LanguageList into its own component, and it began to not persist the language selection in state.
- I realized that the parent (LanguageDropDown) was resetting the child's state. So, when the parent component re-rendered, it reset the list to its default state.
- By lifting the child's state to its parent, then passing it down to the child, the change of language gets persisted in state.